### PR TITLE
Refactor exports and rename async run

### DIFF
--- a/src/bounded_subprocess/__init__.py
+++ b/src/bounded_subprocess/__init__.py
@@ -1,34 +1,17 @@
-"""
-Bounded subprocess execution with timeout and output limits.
+"""Bounded subprocess execution utilities."""
 
-This package provides convenient functions for running subprocesses with bounded
-execution time and output size, with support for both synchronous and asynchronous
-execution patterns.
-"""
+from .bounded_subprocess import run
+from .bounded_subprocess_async import run_async
+from .interactive import Interactive
+from .interactive_async import Interactive as InteractiveAsync
+from .util import Result
 
-__version__ = "1.0.0"
-
-# Lazy imports for better startup performance
-def __getattr__(name):
-    if name == "run":
-        from .bounded_subprocess import run
-        return run
-    elif name == "Result":
-        from .util import Result
-        return Result
-    elif name == "BoundedSubprocessState": 
-        from .util import BoundedSubprocessState
-        return BoundedSubprocessState
-    elif name == "SLEEP_BETWEEN_READS":
-        from .util import SLEEP_BETWEEN_READS
-        return SLEEP_BETWEEN_READS
-    else:
-        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-# Expose key classes and constants for convenience
 __all__ = [
     "run",
-    "Result", 
-    "BoundedSubprocessState",
-    "SLEEP_BETWEEN_READS"
+    "run_async",
+    "Interactive",
+    "InteractiveAsync",
+    "Result",
 ]
+
+__version__ = "1.0.0"

--- a/src/bounded_subprocess/bounded_subprocess_async.py
+++ b/src/bounded_subprocess/bounded_subprocess_async.py
@@ -3,7 +3,7 @@ from typing import List
 from .util import Result, BoundedSubprocessState, SLEEP_BETWEEN_READS
 
 
-async def run(
+async def run_async(
     args: List[str],
     timeout_seconds: int = 15,
     max_output_size: int = 2048,

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -1,5 +1,5 @@
 import pytest
-from bounded_subprocess.bounded_subprocess_async import run
+from bounded_subprocess import run_async
 from pathlib import Path
 import asyncio
 import time
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parent / "evil_programs"
 
 
 async def assert_no_running_evil():
-    result = await run(["pgrep", "-f", ROOT], timeout_seconds=1, max_output_size=1024)
+    result = await run_async(["pgrep", "-f", ROOT], timeout_seconds=1, max_output_size=1024)
     assert (
         result.exit_code == 1
     ), f"There are still evil processes running: {result.stdout}"
@@ -21,7 +21,7 @@ async def assert_no_running_evil():
 async def test_fork_once():
     # The program exits cleanly and immediately. But, it forks a child that runs
     # forever.
-    result = await run(
+    result = await run_async(
         ["python3", ROOT / "fork_once.py"],
         timeout_seconds=2,
         max_output_size=1024,
@@ -36,7 +36,7 @@ async def test_fork_once():
 @pytest.mark.asyncio
 async def test_close_outputs():
     # The program prints to stdout, closes its output, and then runs forever.
-    result = await run(
+    result = await run_async(
         ["python3", ROOT / "close_outputs.py"],
         timeout_seconds=2,
         max_output_size=1024,
@@ -50,7 +50,7 @@ async def test_close_outputs():
 
 @pytest.mark.asyncio
 async def test_unbounded_output():
-    result = await run(
+    result = await run_async(
         ["python3", ROOT / "unbounded_output.py"],
         timeout_seconds=3,
         max_output_size=1024,
@@ -64,7 +64,7 @@ async def test_unbounded_output():
 
 @pytest.mark.asyncio
 async def test_concurrent_sleep():
-    proc = lambda: run(["sleep", "1"], timeout_seconds=2)
+    proc = lambda: run_async(["sleep", "1"], timeout_seconds=2)
     results = await asyncio.gather(proc(), proc(), proc())
     start_time = time.time()
     assert all(r.exit_code == 0 for r in results)


### PR DESCRIPTION
## Summary
- clean up package exports
- rename async `run` to `run_async`
- update async test imports
- stop exporting internal constants

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68404a95021c832d9d7f1d3dc00ae16e