### PR TITLE
Support stdin string in run

### DIFF
--- a/src/bounded_subprocess/bounded_subprocess.py
+++ b/src/bounded_subprocess/bounded_subprocess.py
@@ -1,7 +1,13 @@
 import time
-from typing import List
+from typing import List, Optional
 
-from .util import Result, BoundedSubprocessState, SLEEP_BETWEEN_READS
+from .util import (
+    Result,
+    BoundedSubprocessState,
+    SLEEP_BETWEEN_READS,
+    write_loop_sync,
+    _STDIN_WRITE_TIMEOUT,
+)
 
 
 def run(
@@ -9,13 +15,22 @@ def run(
     timeout_seconds: int = 15,
     max_output_size: int = 2048,
     env=None,
+    stdin_data: Optional[str] = None,
 ) -> Result:
     """
     Runs the given program with arguments. After the timeout elapses, kills the process
     and all other processes in the process group. Captures at most max_output_size bytes
     of stdout and stderr each, and discards any output beyond that.
     """
-    state = BoundedSubprocessState(args, env, max_output_size)
+    state = BoundedSubprocessState(args, env, max_output_size, stdin_data is not None)
+    if stdin_data is not None:
+        write_loop_sync(
+            state.write_chunk,
+            stdin_data.encode(),
+            _STDIN_WRITE_TIMEOUT,
+            sleep_interval=SLEEP_BETWEEN_READS,
+        )
+        state.close_stdin()
 
     # We sleep for 0.1 seconds in each iteration.
     max_iterations = timeout_seconds * 10

--- a/src/bounded_subprocess/bounded_subprocess_async.py
+++ b/src/bounded_subprocess/bounded_subprocess_async.py
@@ -1,6 +1,12 @@
 import asyncio
-from typing import List
-from .util import Result, BoundedSubprocessState, SLEEP_BETWEEN_READS
+from typing import List, Optional
+from .util import (
+    Result,
+    BoundedSubprocessState,
+    SLEEP_BETWEEN_READS,
+    write_loop_async,
+    _STDIN_WRITE_TIMEOUT,
+)
 
 
 async def run(
@@ -8,6 +14,7 @@ async def run(
     timeout_seconds: int = 15,
     max_output_size: int = 2048,
     env=None,
+    stdin_data: Optional[str] = None,
 ) -> Result:
     """
     Runs the given program with arguments. After the timeout elapses, kills the process
@@ -18,7 +25,15 @@ async def run(
     # were going to use asyncio.create_subprocess_exec. But, we're not. We're
     # using subprocess.Popen because it supports non-blocking reads. What's
     # async here? It's just the sleep between reads.
-    state = BoundedSubprocessState(args, env, max_output_size)
+    state = BoundedSubprocessState(args, env, max_output_size, stdin_data is not None)
+    if stdin_data is not None:
+        await write_loop_async(
+            state.write_chunk,
+            stdin_data.encode(),
+            _STDIN_WRITE_TIMEOUT,
+            sleep_interval=SLEEP_BETWEEN_READS,
+        )
+        state.close_stdin()
 
     # We sleep for 0.1 seconds in each iteration.
     max_iterations = timeout_seconds * 10
@@ -31,3 +46,4 @@ async def run(
             break
 
     return state.terminate()
+

--- a/test/evil_programs/echo_stdin.py
+++ b/test/evil_programs/echo_stdin.py
@@ -1,0 +1,4 @@
+import sys
+
+data = sys.stdin.read()
+print(data, end="")

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -117,3 +117,32 @@ def test_long_stdout():
     # leave some leeway space for encoding
     assert 9500 <= len(result.stdout) <= 10500
     assert_no_running_evil()
+
+
+def test_stdin_data_does_not_read():
+    data = "hello world\n"
+    result = run(
+        ["python3", ROOT / "does_not_read.py"],
+        timeout_seconds=2,
+        max_output_size=1024,
+        stdin_data=data,
+    )
+    assert result.exit_code == -1
+    assert result.timeout is True
+    assert len(result.stdout) == 0
+    assert len(result.stderr) == 0
+    assert_no_running_evil()
+
+
+def test_stdin_data_echo():
+    data = "hello world\n"
+    result = run(
+        ["python3", ROOT / "echo_stdin.py"],
+        timeout_seconds=2,
+        max_output_size=1024,
+        stdin_data=data,
+    )
+    assert result.exit_code == 0
+    assert result.timeout is False
+    assert result.stdout == data
+    assert_no_running_evil()

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -72,3 +72,34 @@ async def test_concurrent_sleep():
     assert all(len(r.stderr) == 0 for r in results)
     assert time.time() - start_time < 1.1
     await assert_no_running_evil()
+
+
+@pytest.mark.asyncio
+async def test_stdin_data_async_does_not_read():
+    data = "hello async\n"
+    result = await run(
+        ["python3", ROOT / "does_not_read.py"],
+        timeout_seconds=2,
+        max_output_size=1024,
+        stdin_data=data,
+    )
+    assert result.exit_code == -1
+    assert result.timeout is True
+    assert len(result.stdout) == 0
+    assert len(result.stderr) == 0
+    await assert_no_running_evil()
+
+
+@pytest.mark.asyncio
+async def test_stdin_data_async_echo():
+    data = "hello async\n"
+    result = await run(
+        ["python3", ROOT / "echo_stdin.py"],
+        timeout_seconds=2,
+        max_output_size=1024,
+        stdin_data=data,
+    )
+    assert result.exit_code == 0
+    assert result.timeout is False
+    assert result.stdout == data
+    await assert_no_running_evil()


### PR DESCRIPTION
## Summary
- allow providing `stdin_data` to `run` and `run` async
- implement stdin handling in `BoundedSubprocessState` with sync/async support
- test sending data to processes that never read input
- test sending data to echo program for sync and async cases
- handle stdin writes without blocking

## Testing
- `pip install .`
- `pip install pytest pytest-asyncio pytest-timeout`
- `pytest -m 'not unsafe' -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ada2c63c832d8418b670548877a7