### PR TITLE
Refactor async runner

### DIFF
--- a/src/bounded_subprocess/__init__.py
+++ b/src/bounded_subprocess/__init__.py
@@ -19,10 +19,6 @@ def __getattr__(name):
         from .util import Result
 
         return Result
-    elif name == "BoundedSubprocessState":
-        from .util import BoundedSubprocessState
-
-        return BoundedSubprocessState
     elif name == "SLEEP_BETWEEN_READS":
         from .util import SLEEP_BETWEEN_READS
 
@@ -32,4 +28,4 @@ def __getattr__(name):
 
 
 # Expose key classes and constants for convenience
-__all__ = ["run", "Result", "BoundedSubprocessState", "SLEEP_BETWEEN_READS"]
+__all__ = ["run", "Result", "SLEEP_BETWEEN_READS"]

--- a/src/bounded_subprocess/bounded_subprocess_async.py
+++ b/src/bounded_subprocess/bounded_subprocess_async.py
@@ -1,11 +1,16 @@
 import asyncio
+import os
+import signal
+import time
+import subprocess
 from typing import List, Optional
+
 from .util import (
     Result,
-    BoundedSubprocessState,
-    SLEEP_BETWEEN_READS,
+    set_nonblocking,
+    MAX_BYTES_PER_READ,
     write_nonblocking_async,
-    _STDIN_WRITE_TIMEOUT,
+    read_to_eof_async,
 )
 
 
@@ -17,41 +22,66 @@ async def run(
     stdin_data: Optional[str] = None,
     stdin_write_timeout: Optional[int] = None,
 ) -> Result:
-    """
-    Runs the given program with arguments. After the timeout elapses, kills the process
-    and all other processes in the process group. Captures at most max_output_size bytes
-    of stdout and stderr each, and discards any output beyond that.
-    """
-    # If you read the code for BoundedSubprocessState, you probably thought we
-    # were going to use asyncio.create_subprocess_exec. But, we're not. We're
-    # using subprocess.Popen because it supports non-blocking reads. What's
-    # async here? It's just the sleep between reads.
-    state = BoundedSubprocessState(args, env, max_output_size, stdin_data is not None)
+    """Run a subprocess asynchronously with bounded I/O."""
+
+    deadline = time.time() + timeout_seconds
+
+    p = subprocess.Popen(
+        args,
+        env=env,
+        stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+        bufsize=MAX_BYTES_PER_READ,
+    )
+    process_group_id = os.getpgid(p.pid)
+
+    set_nonblocking(p.stdout)
+    set_nonblocking(p.stderr)
+
+    write_ok = True
     if stdin_data is not None:
+        set_nonblocking(p.stdin)
         write_ok = await write_nonblocking_async(
-            fd=state.p.stdin,
+            fd=p.stdin,
             data=stdin_data.encode(),
-            timeout_seconds=stdin_write_timeout
-            if stdin_write_timeout is not None
-            else 15,
+            timeout_seconds=stdin_write_timeout if stdin_write_timeout is not None else 15,
         )
-        await state.close_stdin_async(_STDIN_WRITE_TIMEOUT)
+        try:
+            p.stdin.close()
+        except (BrokenPipeError, BlockingIOError):
+            pass
 
-    # Notice that we do not immediately terminate if the write fails. This allows
-    # us to read an error message from the process.
+    bufs = await read_to_eof_async(
+        [p.stdout, p.stderr],
+        timeout_seconds=timeout_seconds,
+        max_len=max_output_size,
+    )
 
-    # We sleep for 0.1 seconds in each iteration.
-    max_iterations = timeout_seconds * 10
-
-    for _ in range(max_iterations):
-        keep_reading = state.try_read()
-        if keep_reading:
-            await asyncio.sleep(SLEEP_BETWEEN_READS)
-        else:
+    exit_code = None
+    is_timeout = False
+    while True:
+        rc = p.poll()
+        if rc is not None:
+            exit_code = rc
             break
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            is_timeout = True
+            break
+        await asyncio.sleep(min(0.05, remaining))
 
-    result = state.terminate()
-    if stdin_data is not None and not write_ok:
-        result.exit_code = -1
-        result.stderr = result.stderr + "\nFailed to write all data to subprocess."
-    return result
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+    exit_code = -1 if is_timeout or (stdin_data is not None and not write_ok) else exit_code
+
+    return Result(
+        timeout=is_timeout,
+        exit_code=exit_code if exit_code is not None else -1,
+        stdout=bufs[0].decode(errors="ignore"),
+        stderr=bufs[1].decode(errors="ignore"),
+    )

--- a/src/bounded_subprocess/util.py
+++ b/src/bounded_subprocess/util.py
@@ -11,7 +11,6 @@ import select
 
 MAX_BYTES_PER_READ = 1024
 SLEEP_BETWEEN_READS = 0.1
-_STDIN_WRITE_TIMEOUT = 15
 SLEEP_BETWEEN_WRITES = 0.01
 
 
@@ -168,6 +167,58 @@ def read_to_eof_sync(
     return [bytes(bufs[fd]) for fd in files]
 
 
+async def _wait_for_any_read(fds, timeout: float):
+    """Wait until any of the fds is readable or the timeout elapses."""
+    loop = asyncio.get_running_loop()
+    fut = loop.create_future()
+
+    def make_cb(fd):
+        return lambda: (not fut.done()) and fut.set_result(fd)
+
+    for fd in fds:
+        loop.add_reader(fd.fileno(), make_cb(fd))
+    try:
+        return await asyncio.wait_for(fut, timeout)
+    except asyncio.TimeoutError:
+        return None
+    finally:
+        for fd in fds:
+            loop.remove_reader(fd.fileno())
+
+
+async def read_to_eof_async(
+    files: list,
+    *,
+    timeout_seconds: int,
+    max_len: int,
+) -> List[bytes]:
+    """Asynchronously read from nonblocking FDs until EOF or timeout."""
+    bufs = {fd: bytearray() for fd in files}
+    avail = list(files)
+    end_at = time.time() + timeout_seconds
+
+    while avail and time.time() < end_at:
+        remaining = max(0, end_at - time.time())
+        fd = await _wait_for_any_read(avail, remaining)
+        if fd is None:
+            break
+        try:
+            chunk = fd.read(MAX_BYTES_PER_READ)
+            if not chunk:
+                avail.remove(fd)
+                continue
+            buf = bufs[fd]
+            if len(buf) < max_len:
+                keep = max_len - len(buf)
+                buf.extend(chunk[:keep])
+        except (BlockingIOError, InterruptedError):
+            pass
+        except OSError:
+            avail.remove(fd)
+
+    return [bytes(bufs[fd]) for fd in files]
+
+
 # This function is very similar to write_nonblocking_async. But, in my
 # opinion, trying to build an abstraction that works for both sync and async
 # code is painful and a deficiency of Python.
@@ -213,135 +264,3 @@ def write_nonblocking_sync(*, fd, data: bytes, timeout_seconds: int) -> bool:
     return True
 
 
-class BoundedSubprocessState:
-    """State shared between synchronous and asynchronous subprocess helpers."""
-
-    def __init__(self, args, env, max_output_size, use_stdin_pipe: bool = False):
-        """
-        Start the process in a new session.
-        """
-        p = subprocess.Popen(
-            args,
-            env=env,
-            stdin=subprocess.PIPE if use_stdin_pipe else subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            start_new_session=True,
-            bufsize=MAX_BYTES_PER_READ,
-        )
-        set_nonblocking(p.stdout)
-        set_nonblocking(p.stderr)
-        if use_stdin_pipe:
-            set_nonblocking(p.stdin)
-
-        self.process_group_id = os.getpgid(p.pid)
-        self.p = p
-        self.exit_code = None
-        self.stdout_saved_bytes = []
-        self.stderr_saved_bytes = []
-        self.stdout_bytes_read = 0
-        self.stderr_bytes_read = 0
-        self.max_output_size = max_output_size
-
-    def write_chunk(self, data: memoryview) -> tuple[int, bool]:
-        if self.p.stdin is None:
-            return 0, False
-        try:
-            written = self.p.stdin.write(data)
-            self.p.stdin.flush()
-            if written is None:
-                written = 0
-            return written, True
-        except BlockingIOError as exn:
-            if exn.errno != errno.EAGAIN:
-                return exn.characters_written, False
-            return exn.characters_written, True
-        except BrokenPipeError:
-            return 0, False
-
-    def close_stdin(self, timeout: int) -> None:
-        """
-        Closing stdin will block if the other process has not yet read all data.
-        So, we try to close stdin, without blocking, and give up if necessary.
-
-        Closing stdin is not necessary, but is customary, from what I recall from
-        an OS class from 2004.
-        """
-        if self.p.stdin is None:
-            return
-        for _ in range(timeout):
-            try:
-                self.p.stdin.close()
-                return
-            except BlockingIOError:
-                time.sleep(1)
-            except BrokenPipeError:
-                return
-
-    async def close_stdin_async(self, timeout: int) -> None:
-        """
-        See close_stdin for documentation.
-        """
-        if self.p.stdin is None:
-            return
-        for _ in range(timeout):
-            try:
-                self.p.stdin.close()
-                return
-            except BlockingIOError:
-                await asyncio.sleep(1)
-            except BrokenPipeError:
-                return
-
-    def try_read(self) -> bool:
-        """
-        Reads from the process. Returning False indicates that we should stop
-        reading.
-        """
-        this_stdout_read = self.p.stdout.read(MAX_BYTES_PER_READ)
-        this_stderr_read = self.p.stderr.read(MAX_BYTES_PER_READ)
-        # this_stdout_read and this_stderr_read may be None if stdout or stderr
-        # are closed. Without these checks, test_close_output fails.
-        if (
-            this_stdout_read is not None
-            and self.stdout_bytes_read < self.max_output_size
-        ):
-            self.stdout_saved_bytes.append(this_stdout_read)
-            self.stdout_bytes_read += len(this_stdout_read)
-        if (
-            this_stderr_read is not None
-            and self.stderr_bytes_read < self.max_output_size
-        ):
-            self.stderr_saved_bytes.append(this_stderr_read)
-            self.stderr_bytes_read += len(this_stderr_read)
-
-        self.exit_code = self.p.poll()
-        if self.exit_code is not None:
-            # Finish reading output if needed.
-            left_to_read = self.max_output_size - self.stdout_bytes_read
-            if left_to_read <= 0:
-                return False
-            this_stdout_read = self.p.stdout.read(left_to_read)
-            this_stderr_read = self.p.stderr.read(left_to_read)
-            if this_stdout_read is not None:
-                self.stdout_saved_bytes.append(this_stdout_read)
-            if this_stderr_read is not None:
-                self.stderr_saved_bytes.append(this_stderr_read)
-            return False
-        return True
-
-    def terminate(self) -> Result:
-        try:
-            print("TERMI")
-            # Kills the process group. Without this line, test_fork_once fails.
-            os.killpg(self.process_group_id, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-
-        timeout = self.exit_code is None
-        exit_code = self.exit_code if self.exit_code is not None else -1
-        stdout = b"".join(self.stdout_saved_bytes).decode("utf-8", errors="ignore")
-        stderr = b"".join(self.stderr_saved_bytes).decode("utf-8", errors="ignore")
-        return Result(
-            timeout=timeout, exit_code=exit_code, stdout=stdout, stderr=stderr
-        )


### PR DESCRIPTION
## Summary
- rewrite asynchronous `run()` without `BoundedSubprocessState`
- implement non-blocking I/O helpers for async reading

## Testing
- `pip install -q pytest pytest-asyncio pytest-timeout typeguard`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810d314b08832d857ebae0bc98a60c