### PR TITLE
Automate PyPI releases with GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "bounded_subprocess-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for PyPI trusted publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Verify the tag points at a commit on main
+      run: |
+        set -euo pipefail
+        git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+        tagged=$(git rev-parse HEAD^{commit})
+        if ! git merge-base --is-ancestor "$tagged" origin/main; then
+          echo "::error::Tag ${GITHUB_REF_NAME} points at $tagged, which is not on main. Refusing to publish."
+          exit 1
+        fi
+        echo "Tag ${GITHUB_REF_NAME} -> $tagged is on main."
+
+    - name: Verify the package version matches the tag
+      run: |
+        set -euo pipefail
+        tag_version="${GITHUB_REF_NAME#bounded_subprocess-v}"
+        pkg_version=$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')
+        if [ -z "$tag_version" ] || [ "$tag_version" != "$pkg_version" ]; then
+          echo "::error::Tag version '$tag_version' does not match pyproject.toml version '$pkg_version'. Refusing to publish."
+          exit 1
+        fi
+        echo "Publishing bounded_subprocess $pkg_version."
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install the project
+      run: uv sync --locked --all-extras --dev
+
+    - name: Run tests
+      run: uv run python -m pytest -m "not unsafe"
+
+    - name: Build distributions
+      run: uv build
+
+    - name: Publish to PyPI
+      run: uv publish --trusted-publishing always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,29 @@ Use `uv run`to run and not `python`.
 
 ## Publishing Process
 
-Increment the version number as appropriate in pyproject.toml. Delete old
-builds from dist/. Run uv sync to update the lock file. Commit the changes,
-which should have just changes to pyproject.taml and uv.lock. Run `uv build`.
+Releases are automated by `.github/workflows/release.yml`. Pushing a tag named
+`bounded_subprocess-v<version>` publishes to PyPI, but only after the workflow
+confirms that the tagged commit is on `main`, that the tag version matches
+`version` in pyproject.toml, and that the test suite passes.
 
-At this point, stop and tell me to run `uv publish`. Do not try to automate
-this step. Remind me that I must enter __token__ for the username. It says that
-on the screen, but I don't read instructions. The password is in the keychain.
+To cut a release:
+
+1. Increment `version` in pyproject.toml.
+2. Run `uv sync` to update the lock file.
+3. Commit the changes, which should have just changes to pyproject.toml and
+   uv.lock, and get them onto `main`.
+4. Tag that commit `bounded_subprocess-v<version>` (matching pyproject.toml
+   exactly) and push the tag:
+
+   ```
+   git tag bounded_subprocess-v2.9.2
+   git push origin bounded_subprocess-v2.9.2
+   ```
+
+The workflow authenticates to PyPI with trusted publishing (OIDC), so there is
+no API token to manage. If a release fails one of the checks, delete the tag,
+fix the problem, and tag again.
+
+`make build` and `make publish` remain available for publishing by hand, which
+should not be necessary. `uv publish` prompts for credentials: the username is
+`__token__` and the password is in the keychain.


### PR DESCRIPTION
## Summary
This PR automates the release process for publishing to PyPI by introducing a GitHub Actions workflow that triggers on version tags and handles the entire publication pipeline.

## Key Changes
- **Added `.github/workflows/release.yml`**: New automated release workflow that:
  - Triggers on tags matching `bounded_subprocess-v*`
  - Verifies the tagged commit exists on the `main` branch
  - Validates that the tag version matches the version in `pyproject.toml`
  - Runs the test suite to ensure quality
  - Builds and publishes distributions to PyPI using trusted publishing (OIDC)
  - Uses concurrency controls to prevent simultaneous releases

- **Updated `AGENTS.md`**: Revised publishing documentation to reflect the new automated workflow:
  - Simplified release process to: update version → sync dependencies → commit → tag and push
  - Removed manual `uv publish` step from the documented process
  - Documented the tag naming convention and verification checks
  - Noted that trusted publishing eliminates the need to manage API tokens
  - Kept manual publishing instructions as a fallback option

## Implementation Details
- The workflow uses `astral-sh/setup-uv` for dependency management
- Trusted publishing (OIDC) is configured with `id-token: write` permission
- Tag validation ensures only commits on `main` can be released
- Version validation prevents accidental mismatches between tags and package metadata
- Tests marked as "unsafe" are excluded from the release validation run

https://claude.ai/code/session_01Qnd8EihmFbRdcN8iV7sqhu